### PR TITLE
[PFNAC-35] [PFNAC-39] [PFNAC-38] bug fix

### DIFF
--- a/lib/pf/dal/_node_current_session.pm
+++ b/lib/pf/dal/_node_current_session.pm
@@ -42,7 +42,7 @@ BEGIN {
     %DEFAULTS = (
         mac => '',
         last_session_id => '0',
-        is_online => '1',
+        is_online => '0',
     );
 
     @INSERTABLE_FIELDS = qw(

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -390,7 +390,7 @@ sub authorize {
                                 }
                             }
                         }
-        		    }
+                    }
                     if ($online_count >= $max_online_num) {
                         # exceed max online notify
                         my $apiclient = pf::client::getClient;
@@ -415,11 +415,11 @@ sub authorize {
                 my ($status_code, $node_current_session_info) = pf::dal::node_current_session->find_or_create({"mac" => $mac});
                 my $diff = 0;
                 if (is_success($status_code)) {
-		            my $now = localtime;
+                    my $now = localtime;
                     my $target_time = Time::Piece->strptime($node_current_session_info->{'updated'}, "%Y-%m-%d %H:%M:%S");
                     my $now_time = Time::Piece->strptime($now, "%a %b %d %H:%M:%S %Y");
                     $diff = abs($now_time->epoch - $target_time->epoch);
-		}
+                }
                 if ($diff > $roaming_latency)
                 {
                 # online notify

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -382,13 +382,15 @@ sub authorize {
                 {
                     my $online_count = 0;
                     foreach my $node_item ( @$items ) {
-                        my ($status_code, $node_current_session_info) = pf::dal::node_current_session->find_or_create({"mac" => $node_item->{'mac'}});
-                        if (is_success($status_code)) {
-                            if ($node_current_session_info->{'is_online'} == 1) {
-                                $online_count++;
+                        if ($node_item->{'mac'} ne $mac) {
+                            my ($status_code, $node_current_session_info) = pf::dal::node_current_session->find_or_create({"mac" => $node_item->{'mac'}});
+                            if (is_success($status_code)) {
+                                if ($node_current_session_info->{'is_online'} == 1) {
+                                    $online_count++;
+                                }
                             }
                         }
-                    }
+        		    }
                     if ($online_count >= $max_online_num) {
                         # exceed max online notify
                         my $apiclient = pf::client::getClient;
@@ -413,10 +415,10 @@ sub authorize {
                 my ($status_code, $node_current_session_info) = pf::dal::node_current_session->find_or_create({"mac" => $mac});
                 my $diff = 0;
                 if (is_success($status_code)) {
-                    my $now = localtime;
+		            my $now = localtime;
                     my $target_time = Time::Piece->strptime($node_current_session_info->{'updated'}, "%Y-%m-%d %H:%M:%S");
-                    $diff = abs($now->epoch - $target_time->epoch);
-                }
+                                        $diff = abs($now->epoch - $target_time->epoch);
+		}
                 if ($diff > $roaming_latency)
                 {
                 # online notify

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -417,7 +417,8 @@ sub authorize {
                 if (is_success($status_code)) {
 		            my $now = localtime;
                     my $target_time = Time::Piece->strptime($node_current_session_info->{'updated'}, "%Y-%m-%d %H:%M:%S");
-                                        $diff = abs($now->epoch - $target_time->epoch);
+                    my $now_time = Time::Piece->strptime($now, "%a %b %d %H:%M:%S %Y");
+                    $diff = abs($now_time->epoch - $target_time->epoch);
 		}
                 if ($diff > $roaming_latency)
                 {


### PR DESCRIPTION
[[PFNAC-35] exclude current mac when limit max_online](https://github.com/asterfusion/packetfence/commit/2eab009987c3d9dbd8863593a0d7df4c271561e8)

[[PFNAC-39] use UTC timezone for online_notify](https://github.com/asterfusion/packetfence/commit/2fee245f134a92d995f33b24d4e5f187179a076e)

[[PFNAC-38] set is_online default 0 in table _node_current_session](https://github.com/asterfusion/packetfence/commit/f3df3b626ae2b64b08077cb32522d03accda8774)